### PR TITLE
Return Option from root_provider and manually handle panic

### DIFF
--- a/src/session/mpi.rs
+++ b/src/session/mpi.rs
@@ -44,8 +44,8 @@ impl SessionMPI {
         })
     }
 
-    fn root_provider(&self) -> &ProviderSession {
-        &self.provider_sessions[0]
+    fn root_provider(&self) -> Option<&ProviderSession> {
+        self.provider_sessions.first()
     }
 
     pub fn hostfile(&self) -> Fallible<String> {
@@ -79,7 +79,9 @@ impl SessionMPI {
         args: Vec<T>,
         mpiargs: Option<Vec<T>>,
     ) -> Fallible<()> {
-        let root = self.root_provider();
+        let root = self
+            .root_provider()
+            .expect("encountered empty provider sessions");
         let mut cmdline = vec![];
 
         if let Some(args) = mpiargs {


### PR DESCRIPTION
As far as I understand, `SessionMPI` will error out in the constructor should `provider_sessions` collection be empty, and hence, accessing `Vec`'s first element by index will be guaranteed to return a valid object. However, I was thinking that, should you in the future revise your fundamental assumptions about the struct's behaviour, I think it'd be good to protect yourself from random panics and return an `Option<&_>` instead and manually handling the potential error in the caller. This was, you'd at least know where to look. What do you think?