### PR TITLE
Implement build oni the provider side.

### DIFF
--- a/examples/Tutorial.md
+++ b/examples/Tutorial.md
@@ -1,0 +1,40 @@
+# How to run parallel tasks with gumpi
+As an example, we're going to run a simple MPI application,
+simulating the Conway's Game of Life.
+
+Gumpi job configs are TOML files.
+You can find a documented example config file: `examples/game-life.toml`.
+
+First prepare the sources.
+
+```
+git clone https://github.com/marmistrz/game-life.git
+cd game-life
+git archive --format tar -o game-life.tar master
+```
+
+Put the resulting tarball into the folder where the job config
+resides. In this case it's going to be the `examples` subdirectory.
+
+`game-life` is expected to have the following command-line
+
+```
+Usage: ./game-life procs-row procs-col plane-dimension timesteps
+```
+
+hence, using purely MPI, we would use the following command to run the application using 12 processes using a 4x3 process grid, on a 12000x12000 grid and simulate 10 steps:
+
+```
+mpirun -n 12 ./game-life 4 3 12000 10
+```
+
+This corresponds to the first part of the config file:
+```
+progname = "game-life"
+args = ["4", "3", "12000", "10"]
+```
+
+Now we execute the task using gumpi:
+```
+cargo run -- -h 127.0.0.1:61622 --job examples/game-life.toml -n 12
+```

--- a/examples/Tutorial.md
+++ b/examples/Tutorial.md
@@ -38,3 +38,13 @@ Now we execute the task using gumpi:
 ```
 cargo run -- -h 127.0.0.1:61622 --job examples/game-life.toml -n 12
 ```
+
+# Build system-specific notes
+
+Using CMake is failsafe when it comes to the location of the resulting binary -
+CMake will make sure that it always ends up in the right place.
+
+Unfortunately, this is not the case with generic Makefiles.
+Since the application sources are put into the `app` subdirectory, there are two possible approaches. Either:
+* make sure that your makefile will create the executable in the parent directory
+* if your `progname` is `foo`, just prepend `app/`, in this example `progname` should become `app/foo`

--- a/examples/Tutorial.md
+++ b/examples/Tutorial.md
@@ -40,14 +40,22 @@ cargo run -- -h 127.0.0.1:61622 --job examples/game-life.toml -n 12
 ```
 
 # Build system-specific notes
-
+## CMake
 Using CMake is failsafe when it comes to the location of the resulting binary -
 CMake will make sure that it always ends up in the right place.
 
+We build the Release CMake build flavor.
+
+## Make
 Unfortunately, this is not the case with generic Makefiles.
 Since the application sources are put into the `app` subdirectory, there are two possible approaches. Either:
 * make sure that your makefile will create the executable in the parent directory
 * if your `progname` is `foo`, just prepend `app/`, in this example `progname` should become `app/foo`
+
+While the CMake build backend makes sure that the MPI wrappers (`mpicc`, `mpicxx`)are being used,
+this is not the case for the Make backend. Please make sure that your Makefile uses these wrappers.
+
+The main target will be built, just as though you executed `make` on your local machine.
 
 # Compilation options
 

--- a/examples/Tutorial.md
+++ b/examples/Tutorial.md
@@ -48,3 +48,8 @@ Unfortunately, this is not the case with generic Makefiles.
 Since the application sources are put into the `app` subdirectory, there are two possible approaches. Either:
 * make sure that your makefile will create the executable in the parent directory
 * if your `progname` is `foo`, just prepend `app/`, in this example `progname` should become `app/foo`
+
+# Compilation options
+
+The binaries will be built separately on each node, so you may freely use the
+`-march=native` compilation option to apply hardware-specific optimizations.

--- a/examples/game-life.toml
+++ b/examples/game-life.toml
@@ -1,0 +1,14 @@
+# the name of the binary that will be produced
+progname = "game-life"
+# the command line arguments that should be passed to the program
+args = ["4", "3", "12000", "10"]
+# (optional) extra arguments that should be passed to mpirun
+mpiargs = ["--mca", "btl_tcp_if_include", "10.30.8.0/22"]
+
+# (optional) configuration of the sources to be built on the provider machine
+# if missing, gumpi will assume that the binary is already present on the machine
+[sources]
+# path to the tarball containing the sources
+path = "game-life.tar"
+# build system. Supported: "Make" or "CMake"
+mode = "CMake"

--- a/src/jobconfig.rs
+++ b/src/jobconfig.rs
@@ -7,12 +7,24 @@ use std::path::Path;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub enum BuildType {
+    Make,
+    CMake,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Sources {
+    pub path: PathBuf,
+    pub mode: BuildType,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct JobConfig {
     pub progname: String,
     pub args: Vec<String>,
     pub mpiargs: Option<Vec<String>>,
-    pub sources: Option<PathBuf>,
+    pub sources: Option<Sources>,
 }
 
 impl JobConfig {
@@ -38,4 +50,35 @@ pub struct Opt {
     pub hub: SocketAddr,
     #[structopt(short = "j", long = "job")]
     pub jobconfig: PathBuf,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_jobconfig() {
+        let config: JobConfig = toml::from_str(
+            r#"
+            progname = "prog"
+            args = ["4", "3"]
+            mpiargs = ["--mca", "btl_tcp_if_include", "10.30.8.0/22"]
+
+            [sources]
+            path = "prog.zip"
+            mode = "CMake"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.progname, "prog");
+        assert_eq!(config.args, vec!["4", "3"]);
+        assert_eq!(
+            config.mpiargs.unwrap(),
+            vec!["--mca", "btl_tcp_if_include", "10.30.8.0/22"]
+        );
+
+        let sources = config.sources.unwrap();
+        assert_eq!(sources.path, Path::new("prog.zip"));
+        assert_eq!(sources.mode, BuildType::CMake);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn run() -> Fallible<()> {
     let mgr = SessionMPI::init(opt.hub)?;
 
     if let Some(sources) = config.sources {
-        mgr.deploy(&sources)?;
+        mgr.deploy(opt.jobconfig.parent().unwrap(), &sources)?;
     }
     mgr.exec(opt.numproc, config.progname, config.args, config.mpiargs)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,9 @@ fn run() -> Fallible<()> {
     let mgr = SessionMPI::init(opt.hub)?;
 
     if let Some(sources) = config.sources {
+        // It's safe to call unwrap here - at this point opt.jobconfig
+        // is guaranteed to be a valid filepath, which is checked by
+        // JobConfig::from_file
         mgr.deploy(opt.jobconfig.parent().unwrap(), &sources)
             .context("deploying the sources")?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,10 @@ fn run() -> Fallible<()> {
     let config = JobConfig::from_file(&opt.jobconfig).context("reading job config")?;
 
     let mgr = SessionMPI::init(opt.hub)?;
-    println!("HOSTFILE:\n{}", mgr.hostfile()?);
+
+    if let Some(sources) = config.sources {
+        mgr.deploy(&sources)?;
+    }
     mgr.exec(opt.numproc, config.progname, config.args, config.mpiargs)?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,8 @@ fn run() -> Fallible<()> {
     let mgr = SessionMPI::init(opt.hub)?;
 
     if let Some(sources) = config.sources {
-        mgr.deploy(opt.jobconfig.parent().unwrap(), &sources)?;
+        mgr.deploy(opt.jobconfig.parent().unwrap(), &sources)
+            .context("deploying the sources")?;
     }
     mgr.exec(opt.numproc, config.progname, config.args, config.mpiargs)?;
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -29,6 +29,9 @@ struct ProviderSession {
     hub_session: Rc<HubSession>,
 }
 
+const GUMPI_IMAGE_URL: &str = "http://52.31.143.91/dav/gumpi-image.hdi";
+const GUMPI_IMAGE_SHA1: &str = "a5749cd49c2fdc495c2871e2bd5a54eaf9882d2a";
+
 impl ProviderSession {
     pub fn new(hub_session: Rc<HubSession>, peerinfo: PeerInfo) -> Fallible<Self> {
         let node_id = peerinfo.node_id;
@@ -37,8 +40,8 @@ impl ProviderSession {
         let payload = CreateSession {
             env_type: "hd".to_owned(),
             image: Image {
-                url: "http://52.31.143.91/images/gumpi-image.tar.gz".to_owned(),
-                hash: "SHA1:61014e38bf1b5cb94f61444e64400163ecbbdb14".to_owned(),
+                url: GUMPI_IMAGE_URL.to_owned(),
+                hash: format!("SHA1:{}", GUMPI_IMAGE_SHA1),
             },
             name: "gumpi".to_owned(),
             tags: vec![],
@@ -226,7 +229,10 @@ impl HubSession {
     }
 
     pub fn upload_file(&self, file: &Path) -> Fallible<BlobId> {
-        let data = fs::read_to_string(file).context("reading the file")?;
+        let data = fs::read_to_string(file).context(format!(
+            "reading file: {}",
+            file.to_str().expect("file is an invalid UTF-8")
+        ))?;
         self.upload(data)
     }
 

--- a/src/session/mpi.rs
+++ b/src/session/mpi.rs
@@ -136,6 +136,7 @@ impl SessionMPI {
                     "app",
                     "-DCMAKE_C_COMPILER=mpicc",
                     "-DCMAKE_CXX_COMPILER=mpicxx",
+                    "-DCMAKE_BUILD_TYPE=Release",
                 ]
                 .into_iter()
                 .map(String::from)

--- a/src/session/mpi.rs
+++ b/src/session/mpi.rs
@@ -3,6 +3,7 @@ use crate::jobconfig::{BuildType, Sources};
 use failure::{format_err, Fallible, ResultExt};
 use log::{info, warn};
 use std::net::SocketAddr;
+use std::path::Path;
 use std::rc::Rc;
 
 pub struct SessionMPI {
@@ -116,10 +117,12 @@ impl SessionMPI {
         Ok(())
     }
 
-    pub fn deploy(&self, sources: &Sources) -> Fallible<()> {
+    pub fn deploy(&self, config_path: &Path, sources: &Sources) -> Fallible<()> {
+        let tarball_path = config_path.join(&sources.path);
+
         let blob_id = self
             .hub_session
-            .upload_file(&sources.path)
+            .upload_file(&tarball_path)
             .context("uploading file")?;
 
         for provider in &self.provider_sessions {

--- a/src/session/mpi.rs
+++ b/src/session/mpi.rs
@@ -151,7 +151,9 @@ impl SessionMPI {
                 BuildType::CMake => vec![cmake_cmd, make_cmd],
             };
 
-            let out = provider.exec_commands(cmds)?;
+            let out = provider
+                .exec_commands(cmds)
+                .context(format!("compiling the app on node {}", provider.name()))?;
             for out in out {
                 info!("Provider {} compilation output:\n{}", provider.name(), out);
             }


### PR DESCRIPTION
Known limitations:
* the Makefile support is rudimentary (see the tutorial)
* cmake is pretty sensitive to the binary locations (symlinks and wrappers don't work very well with cmake), so we need to use a portable binary distribution for the gu image. With docker sessions we'll be able to call arbitrary commands from the docker image, so this will be no longer needed.
* we only support `.tar` files because gu supports only tars.
* we deploy sequentially on every provider. We could 
    * just create threads/use rayon
    * make the code more even more async-oriented [difficult] 
    * use the wait command of gu [available only for the docker environment, currently doesn't work with the host-direct environment]
