### PR TITLE
Print the JSON body if the deserialization fails and accept long payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ version = "0.1.0"
 dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.18 (git+https://github.com/marmistrz/actix-web)",
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,6 +758,7 @@ version = "0.1.0"
 dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.18 (git+https://github.com/marmistrz/actix-web)",
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,31 @@
 [package]
-name = "gumpi"
-version = "0.1.0"
 authors = ["Marcin Mielniczuk <marmistrz.dev@zoho.eu>"]
 edition = "2018"
-
+name = "gumpi"
+version = "0.1.0"
 [dependencies]
-serde_json = "1.0"
-serde = "1.0"
-failure = "0.1"
-log = "0.4"
-env_logger = "0.6"
-structopt = "0.2"
-dirs = "1.0"
-serde_derive = "1.0"
-toml = "0.4.8"
-gu-net = { git = "https://github.com/golemfactory/golem-unlimited", branch = "gumpi-ethsign" }
-gu-model = { git = "https://github.com/golemfactory/golem-unlimited", branch = "gumpi-ethsign" }
-tokio = "0.1.14"
-futures = "0.1.25"
-actix-web = { git = "https://github.com/marmistrz/actix-web" }
 actix = "0.7.9"
+bytes = "*"
+dirs = "1.0"
+env_logger = "0.6"
+failure = "0.1"
+futures = "0.1.25"
+log = "0.4"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
+structopt = "0.2"
+tokio = "0.1.14"
 tokio-signal = "0.2.7"
+toml = "0.4.8"
+
+[dependencies.actix-web]
+git = "https://github.com/marmistrz/actix-web"
+
+[dependencies.gu-model]
+branch = "gumpi-ethsign"
+git = "https://github.com/golemfactory/golem-unlimited"
+
+[dependencies.gu-net]
+branch = "gumpi-ethsign"
+git = "https://github.com/golemfactory/golem-unlimited"

--- a/src/session.rs
+++ b/src/session.rs
@@ -267,13 +267,14 @@ type BlobId = u64;
     display = "Deserialization failed: {}. Original string: {}",
     error, raw_json
 )]
-pub struct DeserializationError {
+struct DeserializationError {
+    #[fail(cause)]
     error: serde_json::Error,
     raw_json: DisplayBytes,
 }
 
 #[derive(Debug)]
-pub struct DisplayBytes(Bytes);
+struct DisplayBytes(Bytes);
 impl std::fmt::Display for DisplayBytes {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> std::result::Result<(), fmt::Error> {
         match str::from_utf8(&self.0) {
@@ -284,7 +285,7 @@ impl std::fmt::Display for DisplayBytes {
 }
 
 impl DeserializationError {
-    pub fn new(error: serde_json::Error, raw_json: Bytes) -> Self {
+    fn new(error: serde_json::Error, raw_json: Bytes) -> Self {
         let raw_json = DisplayBytes(raw_json);
         Self { error, raw_json }
     }


### PR DESCRIPTION
Closes #20. 
Example error output:

```
[2019-03-11T15:29:32Z INFO  gumpi::session] Creating a slot
[2019-03-11T15:29:32Z INFO  gumpi::session] Uploading a file, id = 1
[2019-03-11T15:29:32Z INFO  gumpi::session] Uploaded a file, id = 1
[2019-03-11T15:29:32Z INFO  gumpi::session::mpi] Downloading the hostfile...
[2019-03-11T15:29:32Z INFO  gumpi::session::mpi] Downloaded: Ok("\"http://127.0.0.1:61622/sessions/2/blobs/1\" file downloaded")
[2019-03-11T15:29:32Z INFO  gumpi::session::mpi] Executing mpirun with args ["--mca", "btl_tcp_if_include", "10.30.8.0/22", "-n", "12", "--hostfile", "hostfile", "game-life", "3", "2", "12000", "10"]...
[2019-03-11T15:29:32Z INFO  gumpi::session] Reply: Session closed
error: Command execution: Deserialization failed: invalid type: sequence, expected a string at line 1 column 7
Original string:
{"Err":["failed to execute command: /home/marcin/.local/share/golemunlimited/sessions/hd/82c10b7b-1e11-4cd8-8d0b-33d3340e79bf/mpirun, [\"--mca\", \"btl_tcp_if_include\", \"10.30.8.0/22\", \"-n\", \"12\", \"--hostfile\", \"hostfile\", \"game-life\", \"3\", \"2\", \"12000\", \"10\"], Output { status: ExitStatus(ExitStatus(256)), stdout: \"\", stderr: \"--------------------------------------------------------------------------\\nThere are not enough slots available in the system to satisfy the 12 slots\\nthat were requested by the application:\\n  game-life\\n\\nEither request fewer slots for your application, or make more slots available\\nfor use.\\n--------------------------------------------------------------------------\\n\" }"]}
```