### PR TITLE
Workaround inconsitent paths on multiple nodes.

### DIFF
--- a/examples/Tutorial.md
+++ b/examples/Tutorial.md
@@ -48,9 +48,7 @@ We build the Release CMake build flavor.
 
 ## Make
 Unfortunately, this is not the case with generic Makefiles.
-Since the application sources are put into the `app` subdirectory, there are two possible approaches. Either:
-* make sure that your makefile will create the executable in the parent directory
-* if your `progname` is `foo`, just prepend `app/`, in this example `progname` should become `app/foo`
+Make sure that your Makefile puts the resulting binary to the top-level project directory.
 
 While the CMake build backend makes sure that the MPI wrappers (`mpicc`, `mpicxx`)are being used,
 this is not the case for the Make backend. Please make sure that your Makefile uses these wrappers.

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,14 +37,26 @@ fn run() -> Fallible<()> {
 
     let mgr = SessionMPI::init(opt.hub)?;
 
+    let deploy_prefix;
     if let Some(sources) = config.sources {
         // It's safe to call unwrap here - at this point opt.jobconfig
         // is guaranteed to be a valid filepath, which is checked by
         // JobConfig::from_file
-        mgr.deploy(opt.jobconfig.parent().unwrap(), &sources)
+        let prefix = mgr
+            .deploy(opt.jobconfig.parent().unwrap(), &sources, &config.progname)
             .context("deploying the sources")?;
+        deploy_prefix = Some(prefix);
+    } else {
+        deploy_prefix = None;
     }
-    mgr.exec(opt.numproc, config.progname, config.args, config.mpiargs)?;
+
+    mgr.exec(
+        opt.numproc,
+        config.progname,
+        config.args,
+        config.mpiargs,
+        deploy_prefix,
+    )?;
 
     Ok(())
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -24,8 +24,8 @@ struct ProviderSession {
     hub_session: Rc<HubSession>,
 }
 
-const GUMPI_IMAGE_URL: &str = "http://52.31.143.91/dav/gumpi-image.hdi";
-const GUMPI_IMAGE_SHA1: &str = "a5749cd49c2fdc495c2871e2bd5a54eaf9882d2a";
+const GUMPI_IMAGE_URL: &str = "http://52.31.143.91/dav/gumpi-image-test.hdi";
+const GUMPI_IMAGE_SHA1: &str = "367c891fb2fc603ab36fae67e8cfe1d1e8c28ff8";
 
 impl ProviderSession {
     pub fn new(hub_session: Rc<HubSession>, peerinfo: PeerInfo) -> Fallible<Self> {

--- a/src/session/mpi.rs
+++ b/src/session/mpi.rs
@@ -78,6 +78,7 @@ impl SessionMPI {
         progname: T,
         args: Vec<T>,
         mpiargs: Option<Vec<T>>,
+        deploy_prefix: Option<String>,
     ) -> Fallible<()> {
         let root = self.root_provider();
         let mut cmdline = vec![];
@@ -85,12 +86,18 @@ impl SessionMPI {
         if let Some(args) = mpiargs {
             cmdline.extend(args.into_iter().map(T::into));
         }
+
+        // We've moved the executable to /tmp in deploy, so now correct the path
+        // to reflect this change.
+        let progname = progname.into();
+        let progname = deploy_prefix.map(|p| p + &progname).unwrap_or(progname);
+
         cmdline.extend(vec![
             "-n".to_owned(),
             nproc.to_string(),
             "--hostfile".to_owned(),
             "hostfile".to_owned(),
-            progname.into(),
+            progname,
         ]);
         cmdline.extend(args.into_iter().map(T::into));
 
@@ -115,7 +122,14 @@ impl SessionMPI {
         Ok(())
     }
 
-    pub fn deploy(&self, config_path: &Path, sources: &Sources) -> Fallible<()> {
+    // Returns: the deployment prefix
+    pub fn deploy(
+        &self,
+        config_path: &Path,
+        sources: &Sources,
+        progname: &str,
+    ) -> Fallible<String> {
+        let app_path = "app".to_owned();
         let tarball_path = config_path.join(&sources.path);
 
         let blob_id = self
@@ -125,20 +139,32 @@ impl SessionMPI {
 
         for provider in &self.provider_sessions {
             provider
-                .download(blob_id, "app".to_owned(), ResourceFormat::Tar)
+                .download(blob_id, app_path.clone(), ResourceFormat::Tar)
                 .context("downloading file")?;
+
+            // If we create a ProviderSession per provider, every session
+            // gets a unique identifier. This means that the resulting executable
+            // resides in a different directory on each of the provider nodes,
+            // which causes mpirun to fail.
+            // As a workaround, we provide a symlink to the /tmp directory
+            // in the image and put the resulting binary there.
+
+            // For the CMake backend we use the EXECUTABLE_OUTPUT_PATH CMake variable
+            // For the Make backend we just move the file around
 
             let cmake_cmd = Command::Exec {
                 executable: "cmake/bin/cmake".to_owned(),
                 args: vec![
-                    "app",
-                    "-DCMAKE_C_COMPILER=mpicc",
-                    "-DCMAKE_CXX_COMPILER=mpicxx",
-                    "-DCMAKE_BUILD_TYPE=Release",
-                ]
-                .into_iter()
-                .map(String::from)
-                .collect(),
+                    app_path.clone(),
+                    "-DCMAKE_C_COMPILER=mpicc".to_owned(),
+                    "-DCMAKE_CXX_COMPILER=mpicxx".to_owned(),
+                    "-DCMAKE_BUILD_TYPE=Release".to_owned(),
+                    "-DEXECUTABLE_OUTPUT_PATH=tmp".to_owned(), // TODO fix path for Make
+                ],
+            };
+            let mv_cmd = Command::Exec {
+                executable: "mv".to_owned(),
+                args: vec!["app/".to_owned() + progname, "tmp/".to_owned()],
             };
             let make_cmd = Command::Exec {
                 executable: "make".to_owned(),
@@ -146,7 +172,7 @@ impl SessionMPI {
             };
 
             let cmds = match &sources.mode {
-                BuildType::Make => vec![make_cmd],
+                BuildType::Make => vec![make_cmd, mv_cmd],
                 BuildType::CMake => vec![cmake_cmd, make_cmd],
             };
 
@@ -157,6 +183,6 @@ impl SessionMPI {
                 info!("Provider {} compilation output:\n{}", provider.name(), out);
             }
         }
-        Ok(())
+        Ok("/tmp/".to_owned())
     }
 }

--- a/src/session/mpi.rs
+++ b/src/session/mpi.rs
@@ -164,7 +164,7 @@ impl SessionMPI {
             };
             let mv_cmd = Command::Exec {
                 executable: "mv".to_owned(),
-                args: vec!["app/".to_owned() + progname, "tmp/".to_owned()],
+                args: vec![[&app_path, progname].join("/"), "tmp/".to_owned()],
             };
             let make_cmd = Command::Exec {
                 executable: "make".to_owned(),


### PR DESCRIPTION
Due to the Golem Unlimited design, every provider has their binaries
placed in a different directory, depending on the UUID of the session.

This change works it around by using a symlink to /tmp and placing
the resulting binary there.