### PR TITLE
Add support for configurable number of threads per process

### DIFF
--- a/src/jobconfig.rs
+++ b/src/jobconfig.rs
@@ -59,8 +59,10 @@ impl JobConfig {
 #[derive(Debug, StructOpt)]
 #[structopt(name = "gumpi", about = "MPI on Golem Unlimited")]
 pub struct Opt {
-    #[structopt(short = "n", long = "numproc")]
+    #[structopt(short = "n", long = "numproc", help = "number of MPI processes")]
     pub numproc: usize,
+    #[structopt(short = "t", long = "numthreads", help = "number of threads per process")]
+    pub numthreads: usize,
     #[structopt(short = "h", long = "hub")]
     pub hub: SocketAddr,
     #[structopt(short = "j", long = "job")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,9 @@ fn gumpi_async(
     config: JobConfig,
 ) -> Fallible<impl Future<Item = (), Error = failure::Error>> {
     let progname = config.progname.clone();
-    let cpus_requested = opt.numproc;
+    let numproc = opt.numproc;
+    let numthreads = opt.numthreads;
+    let cpus_requested = opt.numproc; // TODO this has to be adapted when we allow threads
     let prov_filter = if opt.providers.is_empty() {
         None
     } else {
@@ -145,7 +147,8 @@ fn gumpi_async(
                     .and_then(move |(deploy_prefix, ())| {
                         session
                             .exec(
-                                cpus_requested,
+                                numproc,
+                                numthreads,
                                 config.progname,
                                 config.args,
                                 config.mpiargs,


### PR DESCRIPTION
Tasks:
* [x] assign slots based on the number of threads
* [ ] update the docs
* [ ] set the `OMP_NUM_THREADS` variable on the provider node [needs-gu-changes]
